### PR TITLE
Made the create member buttons member sensitive

### DIFF
--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   Navbar, Container, Nav, Button,
@@ -8,8 +8,18 @@ import {
 import { signOut } from '../utils/auth';
 import SearchBar from './SearchBar';
 import home from '../images/home.png';
+import CreateMemberBtn from './buttons/CreateMemberBtn';
+import { useAuth } from '../utils/context/authContext';
+import { checkUser } from '../api/memberData';
 
 export default function NavBarAuth() {
+  const [member, setMember] = useState();
+
+  const { user } = useAuth();
+  useEffect(() => {
+    checkUser(user.uid)?.then(setMember);
+  }, [user.uid]);
+
   return (
     <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
       <Container>
@@ -30,9 +40,7 @@ export default function NavBarAuth() {
           <Link passHref href="/members">
             <Nav.Link>Members</Nav.Link>
           </Link>
-          <Link passHref href="/member/new">
-            <Nav.Link>Create Member</Nav.Link>
-          </Link>
+          {member ? null : <CreateMemberBtn />}
         </Nav>
         <SearchBar />
         <Button variant="danger" id="signout-btn" onClick={signOut}>Sign Out</Button>

--- a/components/buttons/CreateMemberBtn.js
+++ b/components/buttons/CreateMemberBtn.js
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+import { Nav } from 'react-bootstrap';
+
+export default function CreateMemberBtn() {
+  return (
+    <Link passHref href="/member/new">
+      <Nav.Link>Create Member</Nav.Link>
+    </Link>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,6 @@ export default function Home() {
   useEffect(() => {
     checkUser(user.uid)?.then(setMember);
   }, [user.uid]);
-  console.log(member);
   return (
     member ? <Welcome /> : <MemberForm />
   );

--- a/pages/members.js
+++ b/pages/members.js
@@ -1,13 +1,20 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
 import { Button } from 'react-bootstrap';
-import { getMembers } from '../api/memberData';
+import { checkUser, getMembers } from '../api/memberData';
 import MemberCard from '../components/cards/MemberCard';
+import CreateMemberBtn from '../components/buttons/CreateMemberBtn';
+import { useAuth } from '../utils/context/authContext';
 // import SearchBar from '../components/search/SearchBar';
 
 function ShowMembers() {
   const [members, setMembers] = useState([]);
+  const [userMember, setUserMember] = useState();
+
+  const { user } = useAuth();
+  useEffect(() => {
+    checkUser(user.uid)?.then(setUserMember);
+  }, [user.uid]);
 
   const getAllTheMembers = () => {
     getMembers().then(setMembers);
@@ -20,9 +27,7 @@ function ShowMembers() {
   return (
     <>
       <div className="text-center my-4">
-        <Link href="/member/new" passHref>
-          <Button>Add A Member</Button>
-        </Link>
+        {userMember ? null : <Button size="sm"><CreateMemberBtn /></Button>}
         <div className="d-flex flex-wrap">
           {members.map((member) => (
             <MemberCard key={member.id} memberObj={member} onUpdate={getAllTheMembers} />


### PR DESCRIPTION
## Description
Made create member button a component then made the places where it's implemented ternary statements. Ternary statements make the button appear if the user hasn't created a user member yet and makes it disappear if they have made a user member.

## Motivation and Context
We only want the user to be able to make one member that represents themself, making the button inaccessible after the user creates a member is how we do that.

## How Can This Be Tested?
Can be tested by creating a member, refreshing the page(working on it), and seeing if the button in the nav or on the members page still exists.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
